### PR TITLE
Remove illegal options from 'begin{figure}[here]'.

### DIFF
--- a/homework.tex
+++ b/homework.tex
@@ -222,7 +222,7 @@
     example, the remainder of 2 would correlate to state \(q_2\) because \(7
     \mod 5 = 2\).
 
-    \begin{figure}[here]
+    \begin{figure}[h]
         \centering
         \begin{tikzpicture}[shorten >=1pt,node distance=2cm,on grid,auto]
             \node[state, accepting, initial] (q_0)   {$q_0$};

--- a/homework.tex
+++ b/homework.tex
@@ -86,12 +86,13 @@
 %   - Author
 %
 
-\newcommand{\hmwkTitle}{Homework\ \#2}
-\newcommand{\hmwkDueDate}{February 12, 2014}
+\newcommand{\hmwkTitle}{Homework\ \#1}
+\newcommand{\hmwkDueDate}{February 12, 2016}
+\newcommand{\hmwkDueTime}{2:30pm}
 \newcommand{\hmwkClass}{Calculus}
 \newcommand{\hmwkClassTime}{Section A}
 \newcommand{\hmwkClassInstructor}{Professor Isaac Newton}
-\newcommand{\hmwkAuthorName}{Josh Davis}
+\newcommand{\hmwkAuthorName}{Matthew Berger}
 
 %
 % Title Page
@@ -100,7 +101,7 @@
 \title{
     \vspace{2in}
     \textmd{\textbf{\hmwkClass:\ \hmwkTitle}}\\
-    \normalsize\vspace{0.1in}\small{Due\ on\ \hmwkDueDate\ at 3:10pm}\\
+    \normalsize\vspace{0.1in}\small{Due\ on\ \hmwkDueDate\ at \hmwkDueTime}\\
     \vspace{0.1in}\large{\textit{\hmwkClassInstructor\ \hmwkClassTime}}
     \vspace{3in}
 }


### PR DESCRIPTION
Options were ignored before Tex Live 2015, but now options are checked and unknown options are flagged as errors according to:
https://tex.stackexchange.com/questions/256172/latex-error-unknown-float-option-d

The 'ere' letters were getting flagged. The only option necessary for 'here' would be 'h'. According to:
https://tex.stackexchange.com/questions/35125/how-to-use-the-placement-options-t-h-with-figures

where it says: 

> 'h' means here: Place the figure in the text where the figure environment is written, if there is enough room left on the page
