### PR TITLE
fix font warning: undefined OT1/cmr/bx/sc

### DIFF
--- a/homework.tex
+++ b/homework.tex
@@ -8,6 +8,7 @@
 \usepackage{tikz}
 \usepackage[plain]{algorithm}
 \usepackage{algpseudocode}
+\usepackage{bold-extra}
 
 \usetikzlibrary{automata,positioning}
 


### PR DESCRIPTION
Was using this template for the first time. I came across with this warning and found a fix for it so I thought I would share it if anyone else is wondering the same thing.

Bolt-extra package is designed to enable you to use bold small capitals.

### Warning
```
LaTeX Font Warning: Font shape `OT1/cmr/bx/sc' undefined(Font)              using `OT1/cmr/bx/n' instead on input line 288.
```
### Line 288
```Latex
    Write part of \alg{Quick-Sort($list, start, end$)}
``` 

### Original end result
![kuva](https://user-images.githubusercontent.com/20582490/212001717-05c1606f-ddb5-4521-bf24-6176e6e7703e.png)

### Fixed end result
![kuva](https://user-images.githubusercontent.com/20582490/212001834-cf793ada-dc3a-4afd-a7f3-96623462f7ae.png)

It changes the name into upper case which I think was intention there. I'm quite new with Latex, so please let me know if there is a better fix for this.
